### PR TITLE
docs: Add framework-specific guides

### DIFF
--- a/docs/frameworks/NEXTAUTH_PATTERNS.md
+++ b/docs/frameworks/NEXTAUTH_PATTERNS.md
@@ -1,0 +1,678 @@
+# NextAuth.js Patterns
+
+This guide covers patterns, configurations, and gotchas for NextAuth.js (Auth.js) authentication.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Session Strategies](#session-strategies)
+- [Configuration Patterns](#configuration-patterns)
+- [Rate Limiting](#rate-limiting)
+- [TypeScript Extensions](#typescript-extensions)
+- [Common Providers](#common-providers)
+- [Protected Routes](#protected-routes)
+- [Common Gotchas](#common-gotchas)
+- [Commands Reference](#commands-reference)
+
+---
+
+## Overview
+
+### When to Use This Guide
+
+- Setting up authentication in Next.js
+- Configuring OAuth providers
+- Implementing session management
+- Securing API routes
+
+### Versions Covered
+
+- NextAuth.js v5 (Auth.js)
+- NextAuth.js v4 (notes where different)
+
+---
+
+## Session Strategies
+
+### JWT Strategy (Recommended)
+
+**Best for:**
+- Serverless deployments
+- Stateless architecture
+- Simple setups
+
+**Configuration:**
+```typescript
+// src/lib/auth.ts
+import NextAuth from 'next-auth';
+
+export const { handlers, signIn, signOut, auth } = NextAuth({
+  session: {
+    strategy: 'jwt',
+    maxAge: 30 * 24 * 60 * 60, // 30 days
+  },
+  // ... providers
+});
+```
+
+**Pros:**
+- No database session table needed
+- Works well with serverless
+- Scales horizontally
+
+**Cons:**
+- Can't invalidate sessions server-side
+- Token size increases with data
+- Logout only affects client
+
+### Database Strategy
+
+**Best for:**
+- Need to invalidate sessions
+- Session data is large
+- Compliance requirements
+
+**Configuration:**
+```typescript
+import NextAuth from 'next-auth';
+import { PrismaAdapter } from '@auth/prisma-adapter';
+import { prisma } from '@/lib/prisma';
+
+export const { handlers, signIn, signOut, auth } = NextAuth({
+  adapter: PrismaAdapter(prisma),
+  session: {
+    strategy: 'database',
+    maxAge: 30 * 24 * 60 * 60,
+  },
+  // ... providers
+});
+```
+
+**Pros:**
+- Can revoke sessions server-side
+- Session data in database
+- More control over sessions
+
+**Cons:**
+- Database call per request
+- Requires database adapter
+- More complex setup
+
+---
+
+## Configuration Patterns
+
+### Basic Setup (v5)
+
+**File: `src/lib/auth.ts`**
+```typescript
+import NextAuth from 'next-auth';
+import Credentials from 'next-auth/providers/credentials';
+import bcrypt from 'bcryptjs';
+import { prisma } from '@/lib/prisma';
+
+export const { handlers, signIn, signOut, auth } = NextAuth({
+  providers: [
+    Credentials({
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials?.password) {
+          return null;
+        }
+
+        const user = await prisma.user.findUnique({
+          where: { email: credentials.email as string },
+        });
+
+        if (!user || !user.passwordHash) {
+          return null;
+        }
+
+        const isValid = await bcrypt.compare(
+          credentials.password as string,
+          user.passwordHash
+        );
+
+        if (!isValid) {
+          return null;
+        }
+
+        return {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+        };
+      },
+    }),
+  ],
+  pages: {
+    signIn: '/login',
+    error: '/login',
+  },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.id = user.id;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (token && session.user) {
+        session.user.id = token.id as string;
+      }
+      return session;
+    },
+  },
+});
+```
+
+**File: `src/app/api/auth/[...nextauth]/route.ts`**
+```typescript
+import { handlers } from '@/lib/auth';
+
+export const { GET, POST } = handlers;
+```
+
+### Environment Variables
+
+```env
+# Required
+AUTH_SECRET=your-secret-key-generate-with-openssl
+
+# For v4 compatibility or explicit URL
+NEXTAUTH_URL=http://localhost:3000
+
+# OAuth providers (if using)
+GITHUB_CLIENT_ID=your-github-client-id
+GITHUB_CLIENT_SECRET=your-github-client-secret
+```
+
+**Generate secret:**
+```bash
+openssl rand -base64 32
+```
+
+---
+
+## Rate Limiting
+
+### Why Rate Limit Auth Routes
+
+- Prevent brute force attacks
+- Protect against credential stuffing
+- Reduce abuse
+
+### Implementation Pattern
+
+**File: `src/lib/rate-limit.ts`**
+```typescript
+type RateLimitStore = Map<string, { count: number; resetTime: number }>;
+
+const store: RateLimitStore = new Map();
+
+// Clean up expired entries periodically
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, value] of store.entries()) {
+    if (now > value.resetTime) {
+      store.delete(key);
+    }
+  }
+}, 60000); // Every minute
+
+export interface RateLimitConfig {
+  maxAttempts: number;
+  windowMs: number;
+}
+
+export const RATE_LIMITS = {
+  AUTH_LOGIN: { maxAttempts: 5, windowMs: 15 * 60 * 1000 },     // 5 per 15 min
+  AUTH_REGISTER: { maxAttempts: 3, windowMs: 60 * 60 * 1000 }, // 3 per hour
+  API_GENERAL: { maxAttempts: 100, windowMs: 60 * 1000 },      // 100 per min
+};
+
+export function checkRateLimit(
+  key: string,
+  config: RateLimitConfig
+): { allowed: boolean; remaining: number; resetIn: number } {
+  const now = Date.now();
+  const record = store.get(key);
+
+  if (!record || now > record.resetTime) {
+    store.set(key, { count: 1, resetTime: now + config.windowMs });
+    return { 
+      allowed: true, 
+      remaining: config.maxAttempts - 1,
+      resetIn: config.windowMs 
+    };
+  }
+
+  if (record.count >= config.maxAttempts) {
+    return { 
+      allowed: false, 
+      remaining: 0,
+      resetIn: record.resetTime - now 
+    };
+  }
+
+  record.count++;
+  return { 
+    allowed: true, 
+    remaining: config.maxAttempts - record.count,
+    resetIn: record.resetTime - now 
+  };
+}
+
+export function getClientIP(request: Request): string {
+  return (
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-real-ip') ||
+    'unknown'
+  );
+}
+```
+
+**Usage in Auth Route:**
+```typescript
+// src/app/api/auth/[...nextauth]/route.ts
+import { handlers } from '@/lib/auth';
+import { checkRateLimit, getClientIP, RATE_LIMITS } from '@/lib/rate-limit';
+import { NextRequest, NextResponse } from 'next/server';
+
+async function rateLimitedHandler(
+  request: NextRequest,
+  handler: (req: NextRequest) => Promise<Response>
+) {
+  // Only rate limit credential submissions
+  if (request.method === 'POST') {
+    const ip = getClientIP(request);
+    const result = checkRateLimit(`auth:${ip}`, RATE_LIMITS.AUTH_LOGIN);
+    
+    if (!result.allowed) {
+      return NextResponse.json(
+        { error: 'Too many attempts. Please try again later.' },
+        { 
+          status: 429,
+          headers: {
+            'Retry-After': String(Math.ceil(result.resetIn / 1000)),
+          },
+        }
+      );
+    }
+  }
+  
+  return handler(request);
+}
+
+export async function GET(request: NextRequest) {
+  return handlers.GET(request);
+}
+
+export async function POST(request: NextRequest) {
+  return rateLimitedHandler(request, handlers.POST);
+}
+```
+
+---
+
+## TypeScript Extensions
+
+### Extending Session Type
+
+**File: `src/types/next-auth.d.ts`**
+```typescript
+import 'next-auth';
+import { DefaultSession } from 'next-auth';
+
+declare module 'next-auth' {
+  interface Session {
+    user: {
+      id: string;
+      role?: string;
+    } & DefaultSession['user'];
+  }
+
+  interface User {
+    id: string;
+    role?: string;
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    id: string;
+    role?: string;
+  }
+}
+```
+
+### Using Extended Types
+
+```typescript
+import { auth } from '@/lib/auth';
+
+export default async function Page() {
+  const session = await auth();
+  
+  if (session?.user) {
+    // TypeScript knows about session.user.id
+    console.log(session.user.id);
+    console.log(session.user.role);
+  }
+}
+```
+
+---
+
+## Common Providers
+
+### Credentials Provider
+
+```typescript
+import Credentials from 'next-auth/providers/credentials';
+
+Credentials({
+  credentials: {
+    email: { label: 'Email', type: 'email' },
+    password: { label: 'Password', type: 'password' },
+  },
+  async authorize(credentials) {
+    // Validate and return user or null
+  },
+})
+```
+
+### GitHub Provider
+
+```typescript
+import GitHub from 'next-auth/providers/github';
+
+GitHub({
+  clientId: process.env.GITHUB_CLIENT_ID!,
+  clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+})
+```
+
+### Google Provider
+
+```typescript
+import Google from 'next-auth/providers/google';
+
+Google({
+  clientId: process.env.GOOGLE_CLIENT_ID!,
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+})
+```
+
+### Multiple Providers
+
+```typescript
+export const { handlers, auth } = NextAuth({
+  providers: [
+    Credentials({ /* ... */ }),
+    GitHub({ /* ... */ }),
+    Google({ /* ... */ }),
+  ],
+});
+```
+
+---
+
+## Protected Routes
+
+### Server Component Protection
+
+```typescript
+import { auth } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+
+export default async function ProtectedPage() {
+  const session = await auth();
+  
+  if (!session) {
+    redirect('/login');
+  }
+  
+  return <div>Welcome, {session.user?.name}</div>;
+}
+```
+
+### API Route Protection
+
+```typescript
+import { auth } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const session = await auth();
+  
+  if (!session) {
+    return NextResponse.json(
+      { error: 'Unauthorized' },
+      { status: 401 }
+    );
+  }
+  
+  // Protected logic here
+  return NextResponse.json({ data: 'secret' });
+}
+```
+
+### Middleware Protection
+
+**File: `src/middleware.ts`**
+```typescript
+import { auth } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+
+export default auth((req) => {
+  const isLoggedIn = !!req.auth;
+  const isOnDashboard = req.nextUrl.pathname.startsWith('/dashboard');
+  const isOnAuth = req.nextUrl.pathname.startsWith('/login') || 
+                   req.nextUrl.pathname.startsWith('/register');
+
+  if (isOnDashboard && !isLoggedIn) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+
+  if (isOnAuth && isLoggedIn) {
+    return NextResponse.redirect(new URL('/dashboard', req.url));
+  }
+
+  return NextResponse.next();
+});
+
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+};
+```
+
+### Client-Side Protection
+
+```typescript
+'use client';
+
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+export function ProtectedComponent({ children }: { children: React.ReactNode }) {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/login');
+    }
+  }, [status, router]);
+
+  if (status === 'loading') {
+    return <div>Loading...</div>;
+  }
+
+  if (!session) {
+    return null;
+  }
+
+  return <>{children}</>;
+}
+```
+
+---
+
+## Common Gotchas
+
+### 1. Callback URL Mismatch
+
+**Symptoms:**
+- OAuth redirects fail
+- "Callback URL mismatch" errors
+
+**Causes:**
+- Wrong port (not 3000)
+- HTTP vs HTTPS mismatch
+- Wrong `NEXTAUTH_URL`
+
+**Solution:**
+```env
+NEXTAUTH_URL=http://localhost:3000
+```
+And ensure OAuth provider callback URLs match exactly.
+
+### 2. Session is Null in Client Component
+
+**Cause:** Missing SessionProvider.
+
+**Solution:**
+```typescript
+// src/app/layout.tsx
+import { SessionProvider } from 'next-auth/react';
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        <SessionProvider>{children}</SessionProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+### 3. TypeScript Error: Property 'id' Missing
+
+**Cause:** Session type not extended.
+
+**Solution:** Add type declaration file (see [TypeScript Extensions](#typescript-extensions)).
+
+### 4. Infinite Redirect Loop
+
+**Causes:**
+- Middleware too broad
+- Protected page redirects to protected page
+
+**Solution:**
+```typescript
+// Exclude auth pages from middleware
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|login|register).*)'],
+};
+```
+
+### 5. CSRF Token Missing
+
+**Cause:** Usually a cookie issue.
+
+**Solutions:**
+- Check `NEXTAUTH_URL` matches actual URL
+- Ensure cookies are enabled
+- Check for HTTPS in production
+
+### 6. Credentials Provider: User Always Null
+
+**Cause:** `authorize` returning wrong format.
+
+**Solution:** Return object with at least `id` property:
+```typescript
+return {
+  id: user.id,        // Required
+  email: user.email,
+  name: user.name,
+};
+```
+
+### 7. Session Not Persisting Across Pages
+
+**Causes:**
+- Cookies not working (domain mismatch)
+- Session strategy mismatch
+
+**Solution:**
+- Check cookie settings
+- Ensure consistent session strategy
+- Verify `AUTH_SECRET` is set
+
+---
+
+## Commands Reference
+
+### Environment Setup
+
+```bash
+# Generate AUTH_SECRET
+openssl rand -base64 32
+
+# Or using Node
+node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+```
+
+### Common Operations
+
+```typescript
+// Server-side: Get session
+import { auth } from '@/lib/auth';
+const session = await auth();
+
+// Server-side: Sign in
+import { signIn } from '@/lib/auth';
+await signIn('credentials', { email, password });
+
+// Server-side: Sign out
+import { signOut } from '@/lib/auth';
+await signOut();
+
+// Client-side: Get session
+import { useSession } from 'next-auth/react';
+const { data: session, status } = useSession();
+
+// Client-side: Sign in
+import { signIn } from 'next-auth/react';
+await signIn('credentials', { email, password, redirectTo: '/dashboard' });
+
+// Client-side: Sign out
+import { signOut } from 'next-auth/react';
+await signOut({ redirectTo: '/' });
+```
+
+---
+
+## Related Documentation
+
+- [CLAUDE.md](../../CLAUDE.md) - Project guidelines
+- [Next.js Patterns](NEXTJS_PATTERNS.md) - Framework integration
+- [Prisma Patterns](PRISMA_PATTERNS.md) - Database adapter
+- [Coding Standards](../guides/CODING_STANDARDS.md) - Code quality
+
+### External Resources
+
+- [Auth.js Documentation](https://authjs.dev)
+- [NextAuth.js v5 Migration](https://authjs.dev/getting-started/migrating-to-v5)
+- [Auth.js Prisma Adapter](https://authjs.dev/reference/adapter/prisma)
+
+---
+
+**Last Updated:** 2024-12-08
+**Maintained By:** Development Team

--- a/docs/frameworks/NEXTJS_PATTERNS.md
+++ b/docs/frameworks/NEXTJS_PATTERNS.md
@@ -1,0 +1,508 @@
+# Next.js Patterns
+
+This guide covers patterns, configurations, and gotchas for Next.js projects, with a focus on the App Router (Next.js 13+).
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Port Management](#port-management)
+- [Cache Management](#cache-management)
+- [Environment Variables](#environment-variables)
+- [App Router Patterns](#app-router-patterns)
+- [API Routes](#api-routes)
+- [Common Gotchas](#common-gotchas)
+- [Commands Reference](#commands-reference)
+
+---
+
+## Overview
+
+### When to Use This Guide
+
+- Starting a new Next.js project
+- Troubleshooting Next.js issues
+- Setting up development environment
+- Understanding App Router patterns
+
+### Versions Covered
+
+- Next.js 13+ (App Router)
+- React 18+
+- TypeScript
+
+---
+
+## Port Management
+
+### The Rule
+
+**Always use port 3000 for development.**
+
+### Why This Matters
+
+Authentication systems (NextAuth, OAuth providers) rely on callback URLs. If you use a different port:
+
+- OAuth callbacks fail
+- NextAuth sessions break
+- Redirect loops occur
+- Cookies don't work correctly
+
+### Configuration
+
+**In package.json:**
+```json
+{
+  "scripts": {
+    "dev": "next dev -p 3000",
+    "dev:clean": "rm -rf .next && next dev -p 3000"
+  }
+}
+```
+
+**In CLAUDE.md:**
+```markdown
+## Port Management
+
+Always use port 3000. If the port is in use:
+
+1. Find the process: `netstat -ano | findstr :3000` (Windows) or `lsof -i :3000` (Mac/Linux)
+2. Kill it before starting dev server
+```
+
+### If Port 3000 is Occupied
+
+**Windows (PowerShell):**
+```powershell
+# Find process
+netstat -ano | findstr :3000
+
+# Kill by PID
+taskkill /F /PID <PID>
+```
+
+**macOS/Linux:**
+```bash
+# Find and kill
+lsof -ti :3000 | xargs kill -9
+```
+
+**Never do this:**
+```bash
+# DON'T use alternate ports
+next dev -p 3001  # This will break auth!
+```
+
+---
+
+## Cache Management
+
+### The Problem
+
+Next.js caches aggressively. After pulling changes or switching branches, you may see:
+
+- Stale pages
+- Old styles
+- Cached API responses
+- Build errors from old artifacts
+
+### The Solution
+
+**Clear the cache when:**
+- Pulling new changes
+- Switching branches
+- Seeing stale content
+- Experiencing mysterious errors
+
+**Command:**
+```bash
+rm -rf .next && npx prisma generate && npm run dev
+```
+
+**Or create a script:**
+```json
+{
+  "scripts": {
+    "dev": "next dev -p 3000",
+    "dev:clean": "rm -rf .next && next dev -p 3000",
+    "dev:fresh": "rm -rf .next node_modules/.cache && next dev -p 3000"
+  }
+}
+```
+
+### What to Clear
+
+| Directory | When to Clear | Command |
+|-----------|--------------|--------|
+| `.next/` | Most cache issues | `rm -rf .next` |
+| `node_modules/.cache` | Persistent issues | `rm -rf node_modules/.cache` |
+| `node_modules/` | Dependency issues | `rm -rf node_modules && npm install` |
+
+---
+
+## Environment Variables
+
+### Structure
+
+Next.js has specific rules for environment variables:
+
+| Prefix | Available In | Example |
+|--------|-------------|--------|
+| `NEXT_PUBLIC_` | Client + Server | `NEXT_PUBLIC_API_URL` |
+| (none) | Server only | `DATABASE_URL` |
+
+### File Priority
+
+```
+.env.local           # Local overrides (git-ignored)
+.env.development     # Development defaults
+.env.production      # Production defaults
+.env                 # All environments
+```
+
+### Template (.env.example)
+
+```env
+# Database
+DATABASE_URL=postgresql://user:password@localhost:5432/dbname
+
+# Authentication
+AUTH_SECRET=generate-with-openssl-rand-base64-32
+NEXTAUTH_URL=http://localhost:3000
+
+# Public (client-accessible)
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_API_URL=http://localhost:3000/api
+```
+
+### Accessing Variables
+
+**Server-side (API routes, Server Components):**
+```typescript
+const dbUrl = process.env.DATABASE_URL;
+```
+
+**Client-side (only NEXT_PUBLIC_):**
+```typescript
+const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+```
+
+### Security Rules
+
+- Never prefix secrets with `NEXT_PUBLIC_`
+- Never commit `.env.local`
+- Always commit `.env.example` with placeholders
+- Use different secrets per environment
+
+---
+
+## App Router Patterns
+
+### Directory Structure
+
+```
+src/app/
+├── layout.tsx          # Root layout
+├── page.tsx            # Home page (/)
+├── globals.css         # Global styles
+├── (auth)/             # Route group (no URL impact)
+│   ├── login/
+│   │   └── page.tsx    # /login
+│   └── register/
+│       └── page.tsx    # /register
+├── dashboard/
+│   ├── layout.tsx      # Dashboard layout
+│   ├── page.tsx        # /dashboard
+│   └── settings/
+│       └── page.tsx    # /dashboard/settings
+└── api/
+    └── [...]/route.ts  # API routes
+```
+
+### Server vs Client Components
+
+**Default: Server Components**
+```tsx
+// This is a Server Component by default
+export default function Page() {
+  // Can use async/await directly
+  const data = await fetchData();
+  return <div>{data}</div>;
+}
+```
+
+**Client Components (when needed):**
+```tsx
+'use client';
+
+import { useState } from 'react';
+
+export default function Counter() {
+  const [count, setCount] = useState(0);
+  return <button onClick={() => setCount(c => c + 1)}>{count}</button>;
+}
+```
+
+**When to use Client Components:**
+- useState, useEffect, or other hooks
+- Event handlers (onClick, onChange)
+- Browser APIs
+- Third-party libraries requiring client
+
+### Data Fetching
+
+**Server Component (recommended):**
+```tsx
+async function getData() {
+  const res = await fetch('https://api.example.com/data', {
+    cache: 'no-store' // or 'force-cache' for static
+  });
+  return res.json();
+}
+
+export default async function Page() {
+  const data = await getData();
+  return <main>{/* use data */}</main>;
+}
+```
+
+**With Revalidation:**
+```tsx
+const data = await fetch('https://api.example.com/data', {
+  next: { revalidate: 3600 } // Revalidate every hour
+});
+```
+
+---
+
+## API Routes
+
+### Structure (App Router)
+
+```typescript
+// src/app/api/users/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const users = await db.user.findMany();
+  return NextResponse.json(users);
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const user = await db.user.create({ data: body });
+  return NextResponse.json(user, { status: 201 });
+}
+```
+
+### Dynamic Routes
+
+```typescript
+// src/app/api/users/[id]/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const user = await db.user.findUnique({
+    where: { id: params.id }
+  });
+  
+  if (!user) {
+    return NextResponse.json(
+      { error: 'User not found' },
+      { status: 404 }
+    );
+  }
+  
+  return NextResponse.json(user);
+}
+```
+
+### Error Handling Pattern
+
+```typescript
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    
+    // Validate input
+    const validated = schema.parse(body);
+    
+    // Process
+    const result = await processData(validated);
+    
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: error.errors },
+        { status: 400 }
+      );
+    }
+    
+    console.error('API error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+```
+
+---
+
+## Common Gotchas
+
+### 1. "Module not found" After Installing Package
+
+**Cause:** TypeScript or Next.js cache stale.
+
+**Solution:**
+```bash
+rm -rf .next node_modules/.cache
+npm run dev
+```
+
+### 2. Environment Variable Undefined
+
+**Cause:** Missing `NEXT_PUBLIC_` prefix for client-side variable.
+
+**Solution:**
+```env
+# Server only
+API_SECRET=secret
+
+# Client accessible
+NEXT_PUBLIC_API_URL=http://api.example.com
+```
+
+### 3. Hydration Mismatch Errors
+
+**Cause:** Server and client render different content.
+
+**Solutions:**
+- Use `useEffect` for browser-only code
+- Ensure consistent rendering
+- Check for `typeof window !== 'undefined'` usage
+
+```tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function ClientOnlyComponent() {
+  const [mounted, setMounted] = useState(false);
+  
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  
+  if (!mounted) return null;
+  
+  return <div>{/* Browser-only content */}</div>;
+}
+```
+
+### 4. API Route Returns HTML Instead of JSON
+
+**Cause:** Route file named incorrectly or wrong export.
+
+**Solution:**
+- File must be `route.ts` (not `page.tsx`)
+- Export named functions (`GET`, `POST`, etc.)
+- Don't export `default`
+
+### 5. Static Page Shows Old Data
+
+**Cause:** Page is statically generated and cached.
+
+**Solutions:**
+```typescript
+// Force dynamic rendering
+export const dynamic = 'force-dynamic';
+
+// Or use revalidation
+export const revalidate = 60; // seconds
+
+// Or fetch with no-store
+fetch(url, { cache: 'no-store' });
+```
+
+### 6. Middleware Not Running
+
+**Cause:** Middleware file in wrong location.
+
+**Solution:** Must be at `src/middleware.ts` or `middleware.ts` (project root).
+
+### 7. Auth Callback URL Mismatch
+
+**Cause:** Running on wrong port or URL.
+
+**Solution:**
+- Always use port 3000
+- Ensure `NEXTAUTH_URL` matches actual URL
+- Check OAuth provider callback URL configuration
+
+---
+
+## Commands Reference
+
+### Development
+
+```bash
+# Start dev server
+npm run dev
+
+# Clean start
+rm -rf .next && npm run dev
+
+# With specific port (not recommended)
+next dev -p 3000
+```
+
+### Building
+
+```bash
+# Production build
+npm run build
+
+# Start production server
+npm start
+
+# Analyze bundle
+BUNDLE_ANALYZE=true npm run build
+```
+
+### Debugging
+
+```bash
+# Check for TypeScript errors
+npx tsc --noEmit
+
+# Check for lint errors
+npm run lint
+
+# Clear all caches
+rm -rf .next node_modules/.cache
+```
+
+---
+
+## Related Documentation
+
+- [CLAUDE.md](../../CLAUDE.md) - Project guidelines
+- [Prisma Patterns](PRISMA_PATTERNS.md) - Database integration
+- [NextAuth Patterns](NEXTAUTH_PATTERNS.md) - Authentication
+- [Coding Standards](../guides/CODING_STANDARDS.md) - Code quality
+
+### External Resources
+
+- [Next.js Documentation](https://nextjs.org/docs)
+- [App Router Migration Guide](https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration)
+- [Next.js Examples](https://github.com/vercel/next.js/tree/canary/examples)
+
+---
+
+**Last Updated:** 2024-12-08
+**Maintained By:** Development Team

--- a/docs/frameworks/PRISMA_PATTERNS.md
+++ b/docs/frameworks/PRISMA_PATTERNS.md
@@ -1,0 +1,532 @@
+# Prisma Patterns
+
+This guide covers patterns, configurations, and gotchas for Prisma ORM projects.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Schema Change Workflow](#schema-change-workflow)
+- [Migration Best Practices](#migration-best-practices)
+- [Connection Patterns](#connection-patterns)
+- [Singleton Client Pattern](#singleton-client-pattern)
+- [Query Patterns](#query-patterns)
+- [Common Gotchas](#common-gotchas)
+- [Commands Reference](#commands-reference)
+
+---
+
+## Overview
+
+### When to Use This Guide
+
+- Setting up Prisma in a new project
+- Managing database schema changes
+- Troubleshooting connection issues
+- Optimizing database queries
+
+### What Prisma Provides
+
+- Type-safe database client
+- Schema-as-code
+- Migrations management
+- Query builder with relations
+
+---
+
+## Schema Change Workflow
+
+### The Standard Workflow
+
+When you modify `prisma/schema.prisma`:
+
+```
+1. Edit schema.prisma
+        ↓
+2. Generate client (npx prisma generate)
+        ↓
+3. Push/Migrate to database
+        ↓
+4. Restart dev server
+```
+
+### Development: Push Workflow
+
+For rapid iteration during development:
+
+```bash
+# After editing schema.prisma
+npx prisma db push
+```
+
+This:
+- Syncs schema to database
+- Regenerates Prisma Client
+- Does NOT create migration files
+
+**Use when:**
+- Prototyping
+- Local development
+- Schema is in flux
+
+### Production: Migration Workflow
+
+For production-ready changes:
+
+```bash
+# Create migration
+npx prisma migrate dev --name add_user_roles
+
+# Apply to production
+npx prisma migrate deploy
+```
+
+This:
+- Creates migration SQL files
+- Tracks migration history
+- Safe for production
+
+**Use when:**
+- Schema is stable
+- Deploying to production
+- Need rollback capability
+
+### Quick Reference
+
+| Situation | Command |
+|-----------|--------|
+| Schema changed, need client | `npx prisma generate` |
+| Schema changed, sync to dev DB | `npx prisma db push` |
+| Create production migration | `npx prisma migrate dev --name <name>` |
+| Apply migrations in production | `npx prisma migrate deploy` |
+| Reset database (dev only) | `npx prisma migrate reset` |
+
+---
+
+## Migration Best Practices
+
+### Naming Conventions
+
+Use descriptive migration names:
+
+```bash
+# Good
+npx prisma migrate dev --name add_user_email_verification
+npx prisma migrate dev --name create_posts_table
+npx prisma migrate dev --name add_index_to_users_email
+
+# Bad
+npx prisma migrate dev --name update
+npx prisma migrate dev --name fix
+npx prisma migrate dev --name changes
+```
+
+### Safe Schema Changes
+
+**Safe (no data loss):**
+- Adding new tables
+- Adding nullable columns
+- Adding indexes
+- Adding new enum values at the end
+
+**Requires caution:**
+- Renaming columns (Prisma sees as drop + add)
+- Changing column types
+- Making columns required
+- Removing enum values
+
+### Handling Risky Changes
+
+**Renaming a column:**
+```sql
+-- In migration file, manually change:
+-- DROP COLUMN old_name
+-- ADD COLUMN new_name
+-- To:
+ALTER TABLE "User" RENAME COLUMN "old_name" TO "new_name";
+```
+
+**Making column required:**
+```sql
+-- First, update existing null values
+UPDATE "User" SET "email" = 'unknown@example.com' WHERE "email" IS NULL;
+-- Then alter column
+ALTER TABLE "User" ALTER COLUMN "email" SET NOT NULL;
+```
+
+### Migration Review Checklist
+
+Before applying migrations:
+
+- [ ] Migration name is descriptive
+- [ ] No unintended data loss
+- [ ] Indexes added for frequently queried columns
+- [ ] Foreign keys have appropriate ON DELETE behavior
+- [ ] Migration tested locally
+
+---
+
+## Connection Patterns
+
+### Connection String Structure
+
+```
+postgresql://USER:PASSWORD@HOST:PORT/DATABASE?schema=SCHEMA&options
+```
+
+### Common Connection Strings
+
+**Local Development:**
+```env
+DATABASE_URL="postgresql://postgres:password@localhost:5432/myapp?schema=public"
+```
+
+**Neon (Serverless):**
+```env
+DATABASE_URL="postgresql://user:pass@ep-cool-name-123456.us-east-2.aws.neon.tech/neondb?sslmode=require"
+```
+
+**Supabase:**
+```env
+DATABASE_URL="postgresql://postgres:password@db.xxxxx.supabase.co:5432/postgres"
+```
+
+**PlanetScale (MySQL):**
+```env
+DATABASE_URL="mysql://user:pass@aws.connect.psdb.cloud/mydb?sslaccept=strict"
+```
+
+### Connection Options
+
+| Option | Purpose | Example |
+|--------|---------|--------|
+| `sslmode=require` | Force SSL | Required for most cloud DBs |
+| `connection_limit=5` | Pool size | Limit connections in serverless |
+| `pool_timeout=10` | Pool timeout | Seconds to wait for connection |
+| `connect_timeout=10` | Connect timeout | Initial connection timeout |
+
+### Serverless Considerations
+
+For serverless environments (Vercel, AWS Lambda):
+
+```env
+# Add connection pooling
+DATABASE_URL="postgresql://user:pass@host/db?connection_limit=1"
+```
+
+Or use a connection pooler (PgBouncer, Neon pooling).
+
+---
+
+## Singleton Client Pattern
+
+### The Problem
+
+In development, hot reloading creates multiple Prisma Client instances, exhausting database connections.
+
+### The Solution
+
+**Create `src/lib/prisma.ts`:**
+
+```typescript
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}
+
+export default prisma;
+```
+
+### Usage
+
+```typescript
+import { prisma } from '@/lib/prisma';
+// or
+import prisma from '@/lib/prisma';
+
+// Use in API routes, server components, etc.
+const users = await prisma.user.findMany();
+```
+
+### With Logging (Development)
+
+```typescript
+export const prisma = globalForPrisma.prisma ?? new PrismaClient({
+  log: process.env.NODE_ENV === 'development' 
+    ? ['query', 'error', 'warn'] 
+    : ['error'],
+});
+```
+
+---
+
+## Query Patterns
+
+### Basic CRUD
+
+```typescript
+// Create
+const user = await prisma.user.create({
+  data: { email: 'test@example.com', name: 'Test' }
+});
+
+// Read
+const user = await prisma.user.findUnique({
+  where: { id: 'user-id' }
+});
+
+// Update
+const user = await prisma.user.update({
+  where: { id: 'user-id' },
+  data: { name: 'New Name' }
+});
+
+// Delete
+await prisma.user.delete({
+  where: { id: 'user-id' }
+});
+```
+
+### Relations
+
+```typescript
+// Include relations
+const userWithPosts = await prisma.user.findUnique({
+  where: { id: 'user-id' },
+  include: {
+    posts: true,
+    profile: true
+  }
+});
+
+// Select specific fields
+const userEmail = await prisma.user.findUnique({
+  where: { id: 'user-id' },
+  select: {
+    email: true,
+    posts: {
+      select: { title: true }
+    }
+  }
+});
+```
+
+### Filtering
+
+```typescript
+// Multiple conditions
+const users = await prisma.user.findMany({
+  where: {
+    AND: [
+      { email: { contains: '@company.com' } },
+      { createdAt: { gte: new Date('2024-01-01') } }
+    ]
+  }
+});
+
+// OR conditions
+const users = await prisma.user.findMany({
+  where: {
+    OR: [
+      { email: { contains: 'admin' } },
+      { role: 'ADMIN' }
+    ]
+  }
+});
+```
+
+### Pagination
+
+```typescript
+const pageSize = 10;
+const page = 1;
+
+const users = await prisma.user.findMany({
+  skip: (page - 1) * pageSize,
+  take: pageSize,
+  orderBy: { createdAt: 'desc' }
+});
+
+// Get total count for pagination
+const total = await prisma.user.count();
+```
+
+### Transactions
+
+```typescript
+// Interactive transaction
+const result = await prisma.$transaction(async (tx) => {
+  const user = await tx.user.create({ data: { ... } });
+  const profile = await tx.profile.create({ 
+    data: { userId: user.id, ... } 
+  });
+  return { user, profile };
+});
+
+// Batch transaction
+const [users, posts] = await prisma.$transaction([
+  prisma.user.findMany(),
+  prisma.post.findMany()
+]);
+```
+
+---
+
+## Common Gotchas
+
+### 1. "Can't reach database server"
+
+**Causes:**
+- Database not running
+- Wrong connection string
+- Network/firewall issues
+
+**Solutions:**
+```bash
+# Check connection string
+echo $DATABASE_URL
+
+# Test connection
+npx prisma db pull
+```
+
+### 2. "Prisma Client not generated"
+
+**Cause:** Schema changed but client not regenerated.
+
+**Solution:**
+```bash
+npx prisma generate
+```
+
+### 3. "Record not found" After Create
+
+**Cause:** Using stale client instance.
+
+**Solution:** Use singleton pattern (see above).
+
+### 4. "Too many connections"
+
+**Cause:** Multiple client instances in development.
+
+**Solutions:**
+- Use singleton pattern
+- Add connection limit: `?connection_limit=5`
+- Use connection pooler
+
+### 5. Schema Drift in Team
+
+**Cause:** Different team members have different schema states.
+
+**Solution:**
+```bash
+# Reset and re-apply migrations
+npx prisma migrate reset
+
+# Or pull schema from database
+npx prisma db pull
+```
+
+### 6. Migration Conflicts
+
+**Cause:** Multiple devs creating migrations simultaneously.
+
+**Solution:**
+- Coordinate migration creation
+- Use `prisma migrate resolve` for conflicts
+- Consider squashing migrations periodically
+
+### 7. Enum Changes Not Reflecting
+
+**Cause:** Enum values cached in client.
+
+**Solution:**
+```bash
+npx prisma generate
+# Restart dev server
+```
+
+---
+
+## Commands Reference
+
+### Schema & Client
+
+```bash
+# Generate client from schema
+npx prisma generate
+
+# Format schema file
+npx prisma format
+
+# Validate schema
+npx prisma validate
+```
+
+### Database Sync
+
+```bash
+# Push schema to database (dev)
+npx prisma db push
+
+# Pull schema from database
+npx prisma db pull
+
+# Seed database
+npx prisma db seed
+```
+
+### Migrations
+
+```bash
+# Create migration (dev)
+npx prisma migrate dev --name <name>
+
+# Apply migrations (production)
+npx prisma migrate deploy
+
+# Reset database and migrations
+npx prisma migrate reset
+
+# Check migration status
+npx prisma migrate status
+
+# Resolve migration issues
+npx prisma migrate resolve --applied <migration>
+```
+
+### Utilities
+
+```bash
+# Open Prisma Studio (GUI)
+npx prisma studio
+
+# Execute raw SQL
+npx prisma db execute --file ./script.sql
+```
+
+---
+
+## Related Documentation
+
+- [CLAUDE.md](../../CLAUDE.md) - Project guidelines
+- [Next.js Patterns](NEXTJS_PATTERNS.md) - Framework integration
+- [NextAuth Patterns](NEXTAUTH_PATTERNS.md) - Auth with Prisma adapter
+- [Coding Standards](../guides/CODING_STANDARDS.md) - Code quality
+
+### External Resources
+
+- [Prisma Documentation](https://www.prisma.io/docs)
+- [Prisma Schema Reference](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference)
+- [Prisma Client API](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference)
+
+---
+
+**Last Updated:** 2024-12-08
+**Maintained By:** Development Team

--- a/docs/frameworks/README.md
+++ b/docs/frameworks/README.md
@@ -1,0 +1,102 @@
+# Framework Guides
+
+This directory contains framework-specific documentation, patterns, and gotchas for common tech stacks.
+
+## Available Guides
+
+| Guide | Framework | Description |
+|-------|-----------|-------------|
+| [NEXTJS_PATTERNS.md](NEXTJS_PATTERNS.md) | Next.js | App Router, caching, environment variables |
+| [PRISMA_PATTERNS.md](PRISMA_PATTERNS.md) | Prisma | ORM patterns, migrations, connections |
+| [NEXTAUTH_PATTERNS.md](NEXTAUTH_PATTERNS.md) | NextAuth.js | Authentication, sessions, rate limiting |
+
+## When to Use These Guides
+
+### Starting a New Project
+
+1. Review relevant guides for your tech stack
+2. Copy patterns that apply to your project
+3. Customize the [CLAUDE.md](../../CLAUDE.md) framework section
+
+### Adding a New Framework
+
+When introducing a new framework to an existing project:
+
+1. Check if a guide exists here
+2. Review the patterns before implementing
+3. Update CLAUDE.md with framework-specific notes
+
+### Troubleshooting
+
+These guides include "Common Gotchas" sections that document:
+- Known issues and workarounds
+- Environment-specific problems
+- Integration challenges
+
+## Customizing for Your Project
+
+These guides are **starting points**. Customize for your project:
+
+1. **Copy relevant sections** to your project's CLAUDE.md
+2. **Add project-specific details** (ports, URLs, configs)
+3. **Remove irrelevant content** (frameworks you don't use)
+4. **Add new learnings** as you discover them
+
+## Contributing New Guides
+
+When adding a new framework guide:
+
+1. Use the existing guides as templates
+2. Include these sections:
+   - Overview / Quick Start
+   - Common Patterns
+   - Configuration
+   - Common Gotchas
+   - Commands Reference
+   - Related Documentation
+3. Add to the table above
+4. Cross-reference from CLAUDE.md
+
+## Guide Structure
+
+Each guide follows this structure:
+
+```markdown
+# [Framework] Patterns
+
+## Table of Contents
+
+## Overview
+[What this framework is and when to use it]
+
+## Quick Start
+[Getting started commands and setup]
+
+## Core Patterns
+[Essential patterns for this framework]
+
+## Configuration
+[How to configure the framework]
+
+## Common Gotchas
+[Issues you'll encounter and how to solve them]
+
+## Commands Reference
+[Frequently used commands]
+
+## Related Documentation
+[Links to other docs and external resources]
+```
+
+---
+
+## Related Documentation
+
+- [CLAUDE.md](../../CLAUDE.md) - Project guidelines (includes framework section)
+- [Coding Standards](../guides/CODING_STANDARDS.md) - General code quality
+- [MCP Setup](../integrations/MCP_SETUP.md) - Database server setup
+
+---
+
+**Last Updated:** 2024-12-08
+**Maintained By:** Development Team


### PR DESCRIPTION
## Summary

This PR adds framework-specific documentation with patterns and gotchas for common tech stacks. These guides provide concrete, copy-paste ready examples while being generic enough to adapt.

Closes #27
Part of Epic #22

## Changes

### New Directory: `docs/frameworks/`

1. **`README.md`**
   - Index of all framework guides
   - Guidance on when and how to use them
   - Contributing new guides
   - Guide structure template

2. **`NEXTJS_PATTERNS.md`**
   - Port management (always use 3000 for auth)
   - Cache management workflow
   - Environment variables structure
   - App Router patterns (Server/Client components, data fetching)
   - API route patterns
   - Common gotchas and solutions

3. **`PRISMA_PATTERNS.md`**
   - Schema change workflow (push vs migrate)
   - Migration best practices
   - Connection string patterns (local, Neon, Supabase)
   - Singleton client pattern
   - Query patterns (CRUD, relations, pagination, transactions)
   - Common gotchas and solutions

4. **`NEXTAUTH_PATTERNS.md`**
   - Session strategies (JWT vs Database)
   - Configuration patterns (v5/Auth.js)
   - Rate limiting implementation
   - TypeScript extensions
   - Common providers setup
   - Protected routes (Server, API, Middleware, Client)
   - Common gotchas and solutions

## Test Plan

- [ ] All documents render correctly in GitHub
- [ ] All internal links work
- [ ] Code examples are syntactically correct
- [ ] Commands are copy-paste ready

## Notes

This is PR 3 of 4 in the documentation update epic. Remaining:
- PR 4: Updates to existing documentation (cross-references, new sections)