### PR TITLE
docs: Update existing docs with cross-references

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ New to this template? Start here:
 ### 📖 Development Guides
 Best practices and standards:
 - [CODING_STANDARDS.md](guides/CODING_STANDARDS.md) - Code quality guidelines
+- [CODE_QUALITY_POLICY.md](guides/CODE_QUALITY_POLICY.md) - TODO/FIXME policy, PR standards
 - [BRANCH_STRATEGY.md](guides/BRANCH_STRATEGY.md) - Git workflow guide
 - [DOCUMENTATION_GUIDELINES.md](guides/DOCUMENTATION_GUIDELINES.md) - Documentation best practices
 - [CODE_OF_CONDUCT.md](guides/CODE_OF_CONDUCT.md) - Community guidelines
@@ -20,7 +21,17 @@ Best practices and standards:
 ### 🔄 Workflows
 Development workflow documentation:
 - [CLAUDE_CODE_WORKFLOWS.md](workflows/CLAUDE_CODE_WORKFLOWS.md) - Claude Code best practices
+- [CHANGE_REQUEST_WORKFLOW.md](workflows/CHANGE_REQUEST_WORKFLOW.md) - Research-plan-approve-implement pattern
+- [VISUAL_DEVELOPMENT_WORKFLOW.md](workflows/VISUAL_DEVELOPMENT_WORKFLOW.md) - UI quality control
+- [CI_MONITORING_GUIDE.md](workflows/CI_MONITORING_GUIDE.md) - Automated PR status monitoring
 - [pre-commit-hooks.md](workflows/pre-commit-hooks.md) - Pre-commit hooks guide
+
+### 🔧 Framework Guides
+Framework-specific patterns and gotchas:
+- [frameworks/README.md](frameworks/README.md) - Framework guides index
+- [NEXTJS_PATTERNS.md](frameworks/NEXTJS_PATTERNS.md) - Next.js App Router, caching, env vars
+- [PRISMA_PATTERNS.md](frameworks/PRISMA_PATTERNS.md) - ORM patterns, migrations, connections
+- [NEXTAUTH_PATTERNS.md](frameworks/NEXTAUTH_PATTERNS.md) - Authentication, sessions, rate limiting
 
 ### 🔒 Security
 Security policies and best practices:
@@ -30,6 +41,7 @@ Security policies and best practices:
 ### 🔌 Integrations
 Integration and setup guides:
 - [MCP_SETUP.md](integrations/MCP_SETUP.md) - Model Context Protocol setup
+- [MCP_TROUBLESHOOTING.md](integrations/MCP_TROUBLESHOOTING.md) - MCP troubleshooting guide
 
 ## 🔍 Quick Links
 
@@ -37,22 +49,30 @@ Integration and setup guides:
 1. Read [TEMPLATE_USAGE.md](getting-started/TEMPLATE_USAGE.md)
 2. Follow [POST_TEMPLATE_CHECKLIST.md](getting-started/POST_TEMPLATE_CHECKLIST.md)
 3. Review [CODING_STANDARDS.md](guides/CODING_STANDARDS.md)
+4. Customize [CLAUDE.md](../CLAUDE.md) for your project
 
 **For Contributors:**
 1. Review [CODE_OF_CONDUCT.md](guides/CODE_OF_CONDUCT.md)
 2. Follow [BRANCH_STRATEGY.md](guides/BRANCH_STRATEGY.md)
 3. Check [DOCUMENTATION_GUIDELINES.md](guides/DOCUMENTATION_GUIDELINES.md)
+4. Understand [CHANGE_REQUEST_WORKFLOW.md](workflows/CHANGE_REQUEST_WORKFLOW.md)
 
 **For Security:**
 1. Read [SECURITY.md](security/SECURITY.md) for reporting issues
 2. Review [MCP_SECURITY.md](security/MCP_SECURITY.md) for MCP best practices
 
+**For Framework Setup:**
+1. Review relevant guide in [frameworks/](frameworks/)
+2. Customize CLAUDE.md framework section for your stack
+3. Follow patterns for your tech stack
+
 ## 📂 Other Documentation
 
-- **GitHub Integration:** See [.github/]../.github/) for issue templates, workflows, and project management
+- **GitHub Integration:** See [.github/](../.github/) for issue templates, workflows, and project management
 - **Claude Code:** See [.claude/](../.claude/) for slash commands and configuration
 - **Project Intake:** See [.project-intake/](../.project-intake/) for automated setup system
 - **Testing:** See [testing-template-packet/](../testing-template-packet/) for Django/Docker testing
+- **Project Guidelines:** See [CLAUDE.md](../CLAUDE.md) for development standards
 
 ## 💡 Navigation Tips
 
@@ -60,6 +80,7 @@ Integration and setup guides:
 - Each directory contains related documentation
 - Cross-references use relative links
 - Start with getting-started/ if you're new
+- Framework-specific docs are in frameworks/
 
 ---
 


### PR DESCRIPTION
## Summary

This PR updates existing documentation files with cross-references to the new documentation created in PRs #24, #26, and #28.

Closes #29
Part of Epic #22

## Changes

### Updated: `docs/README.md`
- Added Workflows section with links to new workflow docs:
  - CHANGE_REQUEST_WORKFLOW.md
  - VISUAL_DEVELOPMENT_WORKFLOW.md
  - CI_MONITORING_GUIDE.md
- Added Framework Guides section with links to:
  - frameworks/README.md
  - NEXTJS_PATTERNS.md
  - PRISMA_PATTERNS.md
  - NEXTAUTH_PATTERNS.md
- Added Integrations link to MCP_TROUBLESHOOTING.md
- Added Development Guides link to CODE_QUALITY_POLICY.md
- Updated Quick Links section with framework setup path
- Added reference to CLAUDE.md in Other Documentation

## Dependency Note

This PR should be merged **after** PRs #24, #26, and #28 have been merged, as it references files created in those PRs.

## Test Plan

- [ ] All internal links work after all PRs merged
- [ ] Navigation is intuitive
- [ ] No broken references

## Notes

This is PR 4 of 4 (final) in the documentation update epic #22.

**Merge Order:**
1. PR #24 - CLAUDE.md and core workflow docs
2. PR #26 - Visual/CI workflow docs and MCP troubleshooting
3. PR #28 - Framework guides
4. PR #29 (this PR) - Cross-reference updates